### PR TITLE
Send welcome DM to new members when they join the server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,18 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pip-tools"
+    "pip-tools",
+    "pytest",
+    "pytest-asyncio",
 ]
 # gui = ["PyQt5"]
 # cli = [
 #   "rich",
 #   "click",
 # ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [project.scripts]
 pytexbot-cli = "pytexbot.main:cli_main"

--- a/src/pytexbot/constants.py
+++ b/src/pytexbot/constants.py
@@ -9,3 +9,23 @@ CONFERENCE_2025_ATTENDEES_ROLEID = 1353880344306253866
 CONFERENCE_2026_ATTENDEES_ROLEID = 1490760424885326005
 
 PYTEXAS_GUILD_ID = 1012382914035597372
+
+WELCOME_DM_MESSAGE = """\
+Welcome to the PyTexas Discord community! We're glad you're here.
+
+A few things to help you get started:
+- To keep things enjoyable for everyone, please read the [Server Rules](https://discord.com/channels/1012382914035597372/1012382914555695176/1025464899851268146)
+- Check out #announcements for the latest news
+- If you're attending the PyTexas conference, use /register in the server to get your attendee role
+
+Things you might be looking for:
+- The PyTexas Conference: next happening in Austin in April, 2027.
+- PyTexas Coffee Chats: Come by on Wednesday at 9am to chat with the community.
+- PyTexas Virtual Meetup: Here at 8pm on the First Tuesday of the month.
+- Local Python Communities in Texas: check out the channels in the Locale category.
+
+See you around!
+"""
+
+# TODO:
+# - make dates show up as a countdown?

--- a/src/pytexbot/handlers.py
+++ b/src/pytexbot/handlers.py
@@ -1,0 +1,10 @@
+import discord
+
+from pytexbot.constants import WELCOME_DM_MESSAGE
+
+
+async def send_welcome_dm(member: discord.Member):
+    try:
+        await member.send(WELCOME_DM_MESSAGE)
+    except discord.Forbidden:
+        pass

--- a/src/pytexbot/main.py
+++ b/src/pytexbot/main.py
@@ -23,6 +23,7 @@ from pytexbot.constants import (
     CONFERENCE_2026_ATTENDEES_ROLEID,
     PYTEXAS_GUILD_ID,
 )
+from pytexbot.handlers import send_welcome_dm
 
 # Load config from environment or dotenv file
 load_dotenv()
@@ -102,6 +103,7 @@ class PyTexBotClient(discord.Client):
 
 
 intents = discord.Intents.default()
+intents.members = True
 client = PyTexBotClient(intents=intents)
 
 # alias because reasons
@@ -129,6 +131,11 @@ async def on_ready():
     # Build initial attendee emails list
     client.build_attendee_emails_list()
     print("Ready!\n")
+
+
+@client.event
+async def on_member_join(member: discord.Member):
+    await send_welcome_dm(member)
 
 
 @client.event

--- a/tests/test_welcome.py
+++ b/tests/test_welcome.py
@@ -1,0 +1,23 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from pytexbot.handlers import send_welcome_dm
+from pytexbot.constants import WELCOME_DM_MESSAGE
+
+
+async def test_sends_welcome_dm_to_new_member():
+    member = MagicMock(spec=discord.Member)
+    member.send = AsyncMock()
+
+    await send_welcome_dm(member)
+
+    member.send.assert_called_once_with(WELCOME_DM_MESSAGE)
+
+
+async def test_silently_ignores_forbidden_when_dms_disabled():
+    member = MagicMock(spec=discord.Member)
+    member.send = AsyncMock(side_effect=discord.Forbidden(MagicMock(), "Cannot send messages to this user"))
+
+    await send_welcome_dm(member)  # should not raise


### PR DESCRIPTION
Adds an on_member_join event handler that DMs each new member a welcome message pointing them to `#announcements`, and the `/register` command. Silently ignores `discord.Forbidden` for members who have DMs disabled.

Extracts the handler logic into pytexbot/handlers.py so it can be unit-tested without importing the full bot setup. Adds pytest and pytest-asyncio as dev dependencies with two tests covering the happy path and the DMs-disabled case.

Note: the Server Members Intent must be enabled in the Discord Developer Portal before deploying, or the on_member_join event will not fire.