### PR TITLE
Make compose production-ready

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,12 @@
 services:
 
-  pytexas-discord-bot:
+  pytexbot:
     build: ./
     container_name: pytexas-discord-bot
     env_file:
       - ./.env
+    environment:
+      # Flush stdout/stderr immediately so `docker logs` shows output in real time
+      # instead of waiting for Python's default 8KB buffer to fill.
+      PYTHONUNBUFFERED: "1"
+    restart: unless-stopped


### PR DESCRIPTION
- restart: unless-stopped so the container survives droplet reboots
- PYTHONUNBUFFERED=1 so `docker logs` flushes in real time instead of waiting for Python's default 8KB buffer
- Rename service pytexas-discord-bot -> pytexbot to avoid the pytexas-discord-bot-pytexas-discord-bot stutter in compose's built image name. container_name is preserved so anything referencing it by name keeps working.