### PR TITLE
Add /conference-info slash command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "python-dotenv",
     "requests"
 ]
+
+[tool.setuptools.package-data]
+pytexbot = ["conference_info.toml"]
 # dynamic = []
 
 [project.optional-dependencies]

--- a/src/pytexbot/conference_info.py
+++ b/src/pytexbot/conference_info.py
@@ -1,0 +1,118 @@
+import importlib.resources
+import tomllib
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+
+import discord
+
+
+@dataclass
+class CFPConfig:
+    open_date: date | None = None
+    close_date: date | None = None
+    url: str | None = None
+
+
+@dataclass
+class ConferenceConfig:
+    name: str
+    start_date: date
+    end_date: date
+    description: str = ""
+    location: str | None = None
+    website: str | None = None
+    tickets_url: str | None = None
+    tickets_open_date: date | None = None
+    cfp: CFPConfig = field(default_factory=CFPConfig)
+
+
+def _load_config() -> ConferenceConfig:
+    config_file = importlib.resources.files("pytexbot").joinpath("conference_info.toml")
+    with config_file.open("rb") as f:
+        raw = tomllib.load(f)
+
+    cfp_raw = raw.get("cfp", {})
+    conf_raw = raw["conference"]
+
+    return ConferenceConfig(
+        name=conf_raw["name"],
+        start_date=conf_raw["start_date"],
+        end_date=conf_raw["end_date"],
+        description=conf_raw.get("description", ""),
+        location=conf_raw.get("location"),
+        website=conf_raw.get("website"),
+        tickets_url=conf_raw.get("tickets_url"),
+        tickets_open_date=conf_raw.get("tickets_open_date"),
+        cfp=CFPConfig(
+            open_date=cfp_raw.get("open_date"),
+            close_date=cfp_raw.get("close_date"),
+            url=cfp_raw.get("url"),
+        ),
+    )
+
+
+def _to_unix(d: date) -> int:
+    return int(datetime(d.year, d.month, d.day, tzinfo=timezone.utc).timestamp())
+
+
+def build_conference_embed() -> discord.Embed:
+    conf = _load_config()
+    today = date.today()
+
+    start_ts = _to_unix(conf.start_date)
+    end_ts = _to_unix(conf.end_date)
+
+    embed = discord.Embed(
+        title=conf.name,
+        url=conf.website or "https://pytexas.org",
+        description=conf.description,
+        color=0x7B4EA0,
+    )
+
+    embed.add_field(
+        name="📅 Conference Dates",
+        value=f"<t:{start_ts}:D> – <t:{end_ts}:D> (<t:{start_ts}:R>)",
+        inline=False,
+    )
+
+    if conf.location:
+        embed.add_field(name="📍 Location", value=conf.location, inline=True)
+
+    if conf.website:
+        embed.add_field(name="🌐 Website", value=conf.website, inline=True)
+
+    cfp = conf.cfp
+    if cfp.open_date is None:
+        cfp_value = "CFP dates TBA"
+    elif today < cfp.open_date:
+        ts = _to_unix(cfp.open_date)
+        cfp_value = f"Opens <t:{ts}:D> (<t:{ts}:R>)"
+    elif cfp.close_date is None or today <= cfp.close_date:
+        cfp_value = "**CFP is open now!**"
+        if cfp.close_date:
+            ts = _to_unix(cfp.close_date)
+            cfp_value += f"\nCloses <t:{ts}:D> (<t:{ts}:R>)"
+    else:
+        cfp_value = "CFP is closed"
+
+    if cfp.url:
+        cfp_value += f"\n[Submit a proposal]({cfp.url})"
+
+    embed.add_field(name="📋 Call for Proposals", value=cfp_value, inline=False)
+
+    if conf.tickets_url:
+        if conf.tickets_open_date and today < conf.tickets_open_date:
+            ts = _to_unix(conf.tickets_open_date)
+            ticket_value = f"Sales open <t:{ts}:D> (<t:{ts}:R>)"
+        else:
+            ticket_value = f"[Get your tickets!]({conf.tickets_url})"
+        embed.add_field(name="🎟️ Tickets", value=ticket_value, inline=False)
+    elif conf.tickets_open_date:
+        ts = _to_unix(conf.tickets_open_date)
+        embed.add_field(
+            name="🎟️ Tickets",
+            value=f"Sales open <t:{ts}:D> (<t:{ts}:R>)",
+            inline=False,
+        )
+
+    return embed

--- a/src/pytexbot/conference_info.toml
+++ b/src/pytexbot/conference_info.toml
@@ -1,0 +1,14 @@
+[conference]
+name = "PyTexas 2027"
+start_date = 2027-04-16
+end_date = 2027-04-18
+location = "Austin, TX"
+website = "https://pytexas.org"
+description = "The annual Python community conference for Texas!"
+# tickets_url = "https://pretix.eu/pytexas/2027/"  # uncomment when available
+# tickets_open_date = 2027-01-01                    # uncomment when decided
+
+[cfp]
+open_date = 2026-10-01
+# close_date = 2026-12-01   # uncomment when decided
+# url = "https://pytexas.org/cfp"  # uncomment when the CFP page is live

--- a/src/pytexbot/main.py
+++ b/src/pytexbot/main.py
@@ -24,6 +24,7 @@ from pytexbot.constants import (
     PYTEXAS_GUILD_ID,
 )
 from pytexbot.handlers import send_welcome_dm
+from pytexbot.conference_info import build_conference_embed
 
 # Load config from environment or dotenv file
 load_dotenv()
@@ -219,6 +220,14 @@ async def register(interaction, attendee_email: str):
             await interaction.followup.send(
                 "Oh noes! I couldn't find your email!", ephemeral=True
             )
+
+
+@client.tree.command(name="conference-info", description="Get info about the next PyTexas conference")
+async def conference_info(interaction):
+    """Show dates, CFP status, and links for the upcoming PyTexas conference."""
+    print("Received /conference-info")
+    embed = build_conference_embed()
+    await interaction.response.send_message(embed=embed, ephemeral=True)
 
 
 def cli_main():


### PR DESCRIPTION
Adds a new ephemeral slash command that displays a rich embed with upcoming PyTexas conference details: dates, location, website, CFP status (not yet open / open / closed), and ticket sales when configured.

Conference data is stored in conference_info.toml (packaged alongside the module) and parsed into ConferenceConfig/CFPConfig dataclasses, making dates and URLs easy to update without touching code. Discord timestamp formatting (<t:UNIX:D>) handles timezone display automatically per user.