### PR TITLE
Add /conference-info slash command

### DIFF
--- a/src/pytexbot/conference_info.py
+++ b/src/pytexbot/conference_info.py
@@ -52,7 +52,7 @@ def _load_config() -> ConferenceConfig:
 
 
 def _to_unix(d: date) -> int:
-    return int(datetime(d.year, d.month, d.day, tzinfo=timezone.utc).timestamp())
+    return int(datetime(d.year, d.month, d.day, 12, tzinfo=timezone.utc).timestamp())
 
 
 def build_conference_embed() -> discord.Embed:


### PR DESCRIPTION
## Summary

- Adds a `/conference-info` ephemeral slash command that displays a rich embed with upcoming PyTexas conference details: dates, location, website, CFP status, and ticket sales
- Conference data lives in `conference_info.toml` (packaged with the module) — update dates and URLs there without touching code; fields for CFP close date, CFP URL, and ticket info are pre-wired and just need to be uncommented when decided
- TOML is parsed into `ConferenceConfig` / `CFPConfig` dataclasses before building the embed
- Discord `<t:TIMESTAMP:D>` formatting handles timezone display automatically per user; timestamps use noon UTC to avoid off-by-one rendering in US time zones

## Test plan

- [x] Run the bot locally and invoke `/conference-info` — confirm embed shows correct dates, location, CFP open date, and website link
- [x] Verify the response is only visible to the invoking user (ephemeral)
- [x] Confirm dates render correctly (not one day early) in a US timezone Discord client
- [x] Test CFP state transitions by temporarily adjusting `open_date` in the TOML to a past/future date

🤖 Generated with [Claude Code](https://claude.com/claude-code)